### PR TITLE
fix(egov-hrms): dynamic state tenant check in employee count query

### DIFF
--- a/egov-hrms/src/main/java/org/egov/hrms/repository/EmployeeQueryBuilder.java
+++ b/egov-hrms/src/main/java/org/egov/hrms/repository/EmployeeQueryBuilder.java
@@ -1,6 +1,7 @@
 package org.egov.hrms.repository;
 
 import org.apache.commons.lang3.StringUtils;
+import org.egov.common.utils.MultiStateInstanceUtil;
 import org.egov.hrms.config.PropertiesManager;
 import org.egov.hrms.web.contract.EmployeeSearchCriteria;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +22,9 @@ public class EmployeeQueryBuilder {
 
 	@Autowired
 	private PropertiesManager properties;
+
+	@Autowired
+	private MultiStateInstanceUtil centralInstanceUtil;
 	
 	/**
 	 * Returns query for searching employees
@@ -36,7 +40,7 @@ public class EmployeeQueryBuilder {
 
 	public String getEmployeeCountQuery(String tenantId, List <Object> preparedStmtList ) {
 		StringBuilder builder = new StringBuilder(EmployeeQueries.HRMS_COUNT_EMP_QUERY);
-		if(tenantId.equalsIgnoreCase(properties.stateLevelTenantId)){
+		if(centralInstanceUtil.isTenantIdStateLevel(tenantId)){
 			builder.append("LIKE ? ");
 			preparedStmtList.add(tenantId+"%");
 		}


### PR DESCRIPTION
## Summary
- `EmployeeQueryBuilder.getEmployeeCountQuery()` compared the incoming `tenantId` against a hardcoded `state.level.tenant.id` property to decide between `LIKE` (state-level) and `=` (city-level) SQL predicates
- Replaced with `MultiStateInstanceUtil.isTenantIdStateLevel(tenantId)` which dynamically detects state-level tenants by checking for the absence of a dot separator
- This enables correct employee count queries for any state root (e.g. `tenant`, `ke`), not just the configured default (`pg`)

## Related PRs
- egovernments/Digit-Core#1043 — egov-workflow-v2 dynamic state tenant
- egovernments/Digit-Core#1044 — egov-user dynamic state tenant

## Files Changed
| File | Change |
|------|--------|
| `EmployeeQueryBuilder.java` | Added `MultiStateInstanceUtil` injection, replaced `properties.stateLevelTenantId` comparison with `centralInstanceUtil.isTenantIdStateLevel()` |

## Test plan
- [x] `mvn compile` passes (JDK 17)
- [x] E2E PGR lifecycle on freshly bootstrapped tenant: 21/21 pass
- [x] Full integration test suite: 118/125 pass (1 unrelated failure, 6 known HRMS bugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal tenant validation logic for improved system stability and code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->